### PR TITLE
Suppress duplicated key

### DIFF
--- a/lib/rogc/formats/wms_capabilities/v1.rb
+++ b/lib/rogc/formats/wms_capabilities/v1.rb
@@ -206,10 +206,6 @@ module ROGC
               })
               read_child_nodes(node, obj.logo)
             },
-            'Request' => lambda { |node, obj|
-              obj.request = OpenStruct.new
-              read_child_nodes(node, obj.request)
-            },
             'Style' => lambda { |node, obj|
               style = OpenStruct.new
               obj.styles << style


### PR DESCRIPTION
lib/rogc/formats/wms_capabilities/v1.rb defined twice the 'Request'
key. This commits suppresses the warning
`duplicated key at line 209 ignored: "Request"`
